### PR TITLE
Backtrace when zephyr is not configured for userspace

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -632,7 +632,13 @@ impl Core {
             .filter_map(|(&k, &a)| {
                 self.read_into(a, &mut bytes).ok()?;
                 let out = u32::from_le_bytes(bytes);
-                Some((k, out))
+                // We're deferencing, so all 0 values are dropped, as they're
+                // Null pointers.
+                if out != 0 {
+                    Some((k, out))
+                } else {
+                    None
+                }
             })
             .collect();
         intermediate.typ = dest_type;


### PR DESCRIPTION
Turns out that when zephyr is not configured for userspace, the
mode member of the _thread_arch struct is missing. This caused
errors when attempting to backtrace an application without
userspace configured.

This patch checks for the presence of the mode member, and falls
back to a default value for the PC.