### PR TITLE
Error when a global is missing or a query returns no results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "scroll",
+ "strsim",
  "thiserror",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ pest = "2.1.3"
 pest_derive = "2.1.0"
 maplit = "1.0"
 bitflags = "1.3.2"
+strsim = "0.10.0"
 
 [dependencies.clap]
 version = "3.1"

--- a/src/core.rs
+++ b/src/core.rs
@@ -244,13 +244,6 @@ pub enum QuerySuccess<'a> {
 }
 
 impl<'a> QuerySuccess<'a> {
-    fn from_pair(addr: u32, typ: Gid) -> Self {
-        let addrs = maplit::btreemap! {
-            addr => addr
-        };
-        Self::Addresses(Addresses { addrs, typ })
-    }
-
     pub fn as_mut_addrs<'b>(&'b mut self) -> Option<&'b mut Addresses> {
         if let Self::Addresses(addrs) = self {
             Some(addrs)
@@ -538,16 +531,6 @@ impl Core {
             }
         }
         Ok(intermediate)
-    }
-
-    pub fn filter<'a>(
-        &'a self,
-        filter: &[query::Filter],
-        addr: u32,
-        typ: Gid,
-    ) -> Result<QuerySuccess<'a>> {
-        let intermediate = QuerySuccess::from_pair(addr, typ);
-        self.filter_inner(filter, intermediate)
     }
 
     fn step_cast(&self, cast: &query::Cast, inner: &mut Addresses) -> Result<()> {

--- a/src/core.rs
+++ b/src/core.rs
@@ -468,10 +468,15 @@ impl Core {
     pub fn query<'a>(&'a self, query: &query::Query) -> Result<QuerySuccess<'a>> {
         let globals = self.global_addr(&query.global);
         let (_, typ) = globals.first().ok_or_else(|| {
+            let similar: Vec<_> = self
+                .pack
+                .similar_symbol(&query.global.sym.name)
+                .into_iter()
+                .collect();
             Error::MemberMissing(
                 query.global.span.clone(),
                 query.global.sym.name.clone(),
-                "".to_string(),
+                enumerate(&similar),
             )
         })?;
         let typ = *typ;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,14 @@ use pest::error::Error as PErr;
 use thiserror::Error;
 
 #[derive(Error, Diagnostic, Debug)]
+#[error("Result Dropped")]
+#[diagnostic(severity(warn))]
+pub struct DroppedResult {
+    #[label("dropped an element here")]
+    pub span: SourceSpan,
+}
+
+#[derive(Error, Diagnostic, Debug)]
 pub enum Error {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
@@ -31,6 +39,14 @@ pub enum Error {
         span: SourceSpan,
         expected: String,
         found: String,
+    },
+    #[error("Query returned no results")]
+    #[diagnostic()]
+    NoResults {
+        #[label("no results")]
+        span: SourceSpan,
+        #[related]
+        also: Vec<DroppedResult>,
     },
     #[error("Array bounds unknown")]
     UnsizedArray(#[label] SourceSpan),

--- a/src/main.rs
+++ b/src/main.rs
@@ -665,7 +665,7 @@ fn query_symbols(
 
     let success = bail_src!(core.query(&q), query.clone());
     match success {
-        QuerySuccess::Addresses(Addresses { addrs, typ }) => {
+        QuerySuccess::Addresses(Addresses { addrs, typ, .. }) => {
             if structure {
                 println!(
                     " type {}",


### PR DESCRIPTION
The missing global error looks like:
```
Error:
  × member not found "_kernal"
   ┌─[command-line:1:1]
 1 │ _kernal
   · ───┬───
   ·    └── missing
   └────
  help: consider replacing with "_kernel" instead
  ```
This is quite helpful if you have a typo.

The no-results error looks like:
```

aerology query dhcpv4_client.core.4 '_kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread'`
Error:
  × Query returned no results
   ┌─[command-line:1:1]
 1 │ _kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread
   ·                                                                                                         ─────┬─────
   ·                                                                                                              └── no results
   └────

Error:
  ⚠ Result Dropped
   ┌─[command-line:1:1]
 1 │ _kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread
   ·                                             ─────┬─────
   ·                                                  └── dropped an element here
   └────
Error:
  ⚠ Result Dropped
   ┌─[command-line:1:1]
 1 │ _kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread
   ·                                                         ─────┬─────
   ·                                                              └── dropped an element here
   └────
Error:
  ⚠ Result Dropped
   ┌─[command-line:1:1]
 1 │ _kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread
   ·                                                                     ─────┬─────
   ·                                                                          └── dropped an element here
   └────
Error:
  ⚠ Result Dropped
   ┌─[command-line:1:1]
 1 │ _kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread
   ·                                                                                 ─────┬─────
   ·                                                                                      └── dropped an element here
   └────
Error:
  ⚠ Result Dropped
   ┌─[command-line:1:1]
 1 │ _kernel.threads => llnodes .next_thread => .next_thread.next_thread.next_thread.next_thread.next_thread.next_thread
   ·                                                                                             ─────┬─────
   ·                                                                                                  └── dropped an element here
   └────
```