### PR TITLE
Improve messaging and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The current workflow looks something like:
 Pretty-Print all of the tfm partition control context structures:
 
 ```
-    ;aerology symbol-value dhcpv4_client.core.0 'partition_listhead.llnodes(next).ctx_ctrl'
+    ;aerology query dhcpv4_client.core.0 'partition_listhead => llnodes. next => .ctx_ctrl'
 3000bf60: (struct context_ctrl_t) {
     .sp = (uint32_t) 805347216 /*0x30009f90*/,
     .sp_limit = (uint32_t) 805339336 /*0x300080c8*/,

--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -10,6 +10,3 @@ At the time of writing it is able to provide convinient access to:
  * stack usage by thread, with the `stacks` subcommand
  * backtraces by thread, with the `backtrace` subcommand
  * and general purpose queries beginning with global variables, with the `query` subcommand
-
-This book in structured as a case study of a particular bug, and will assume
-familiarity with both Zephyr and TF-M, where appropriate.

--- a/src/main.rs
+++ b/src/main.rs
@@ -652,6 +652,10 @@ macro_rules! bail_src {
     };
 }
 
+fn needs_core(from: Result<Core>) -> Result<Core> {
+    from.context("Core file not recognized. Did you provide the zap by mistake?")
+}
+
 fn query_symbols(
     QueryArgs {
         pack_file,
@@ -661,7 +665,7 @@ fn query_symbols(
     }: QueryArgs,
 ) -> Result<()> {
     let q: Query = bail_src!(query.clone().parse(), query.clone());
-    let core: Core = pack_file.try_into()?;
+    let core: Core = needs_core(pack_file.try_into().into_diagnostic())?;
 
     let success = bail_src!(core.query(&q), query.clone());
     match success {
@@ -828,7 +832,7 @@ const TTHREADS: &str = "tfm_s::partition_listhead => llnodes .next => .*";
 
 fn print_stacks(args: DtsArgs) -> Result<()> {
     let zthreads_query: Query = ZTHREADS.parse().unwrap();
-    let core: Core = args.pack_file.try_into()?;
+    let core: Core = needs_core(args.pack_file.try_into().into_diagnostic())?;
     let mut out = Vec::new();
     if let Ok(threads) = core.query(&zthreads_query) {
         out.extend(z_stacks(&core, threads).unwrap_or_default().into_iter());
@@ -903,7 +907,7 @@ fn print_thread_bt(core: &Core, regs: Registers, print_regs: bool) {
 }
 
 fn print_backtrace(args: BtArgs) -> Result<()> {
-    let core: Core = args.pack_file.try_into()?;
+    let core: Core = needs_core(args.pack_file.try_into().into_diagnostic())?;
     let regs = core.registers();
     println!("Registers");
     let mut bt = core.backtrace(regs);
@@ -974,7 +978,7 @@ fn print_backtrace(args: BtArgs) -> Result<()> {
 }
 
 fn decode_exc(args: BtArgs) -> Result<()> {
-    let core: Core = args.pack_file.try_into()?;
+    let core: Core = needs_core(args.pack_file.try_into().into_diagnostic())?;
     let mut buf = [0u8; 4];
     if core.read_into(SFSR::ADDR, &mut buf).is_ok() {
         if let Some(sfsr) = SFSR::from_bits(u32::from_le_bytes(buf.clone())) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,12 +56,14 @@ struct PackArgs {
 #[derive(Parser, Debug)]
 struct DtsArgs {
     /// A pack file or core dump to extract info from
+    #[clap(name="CORE_FILE")]
     pack_file: PathBuf,
 }
 
 #[derive(Parser, Debug)]
 struct BtArgs {
     /// A core dump to extract info from
+    #[clap(name="CORE_FILE")]
     pack_file: PathBuf,
     /// Include registers in the backtraces
     #[clap(short, long)]
@@ -71,6 +73,7 @@ struct BtArgs {
 #[derive(Parser, Debug)]
 struct QueryArgs {
     /// A core dump to extract info from
+    #[clap(name="CORE_FILE")]
     pack_file: PathBuf,
     /// The query inself
     query: String,
@@ -85,6 +88,7 @@ struct QueryArgs {
 #[derive(Parser, Debug)]
 struct SegmentsArgs {
     /// A pack file or core dump to extract info from
+    #[clap(name="CORE_OR_ZAP_FILE")]
     pack_file: PathBuf,
     /// Create a summary based on program headers
     #[clap(short, long)]
@@ -93,6 +97,7 @@ struct SegmentsArgs {
 #[derive(Parser, Debug)]
 struct DisArgs {
     /// A pack file or core dump to disassemble from
+    #[clap(name="ZAP_FILE")]
     pack_file: PathBuf,
     /// A symbol, with an optional executable separated by '::'
     symbol: String,
@@ -104,6 +109,7 @@ struct DumpArgs {
     #[clap(short, long)]
     gdb_port: Option<u16>,
     /// Dump the segments from this pack file or core dump
+    #[clap(name="ZAP_FILE")]
     pack_file: PathBuf,
     /// Dump into this file
     dump_file: Option<PathBuf>,


### PR DESCRIPTION
The messaging improvements are:
  * Include context of zap/core in error messages that core is not found
  * fix the help text to refer to CORE_FILEs or CORE_OR_PACK_FILEs instead of PACK_FILEs

Docs:
  * remove incorrect bits in the intro 
  * rework readme example to use current query syntax
