### PR TITLE
Replace filter separator with a '|'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -823,8 +823,8 @@ fn tfm_stacks(core: &Core, threads: QuerySuccess) -> Option<Vec<(String, u64, u6
     Some(out)
 }
 
-const ZTHREADS: &str = "zephyr::_kernel.threads => llnodes .next_thread";
-const TTHREADS: &str = "tfm_s::partition_listhead => llnodes .next => .*";
+const ZTHREADS: &str = "zephyr::_kernel.threads | llnodes .next_thread";
+const TTHREADS: &str = "tfm_s::partition_listhead | llnodes .next | .*";
 
 fn print_stacks(args: DtsArgs) -> Result<()> {
     let zthreads_query: Query = ZTHREADS.parse().unwrap();

--- a/src/query.pest
+++ b/src/query.pest
@@ -18,4 +18,4 @@ reg_assignment = { symbol ~ "=" ~ postfix }
 backtrace = { "bt" ~ (reg_assignment)* }
 llnodes = { "llnodes" ~ member }
 filter = { postfix | backtrace | llnodes | cast }
-query = _{ SOI ~ global ~ postfix? ~ ("=>" ~ filter)* ~ EOI } 
+query = _{ SOI ~ global ~ postfix? ~ ("|" ~ filter)* ~ EOI } 


### PR DESCRIPTION
Now that I have used aerology queries more liberally, I can say
with certainty that '=>' is a bad filter separator. In particular,
This conflicts with a unix shell's redirect output operator, '>',
meaning that aerology will fail silently, writing the error message
to a file specified as the remainder of the query.

Instead, I'm proposing '|' as it will cause bash to treat the rest
of the query as a sequence of commands and they will _probably_ error
in ways that would lead the user to understand the problem.

In both cases, quoting the query is the best option, but '|'
fails more gracefully.